### PR TITLE
refactor: vector 값 받는 형식 변경

### DIFF
--- a/src/main/java/com/tfheauth/face_auth_server/feature/Feature.java
+++ b/src/main/java/com/tfheauth/face_auth_server/feature/Feature.java
@@ -9,9 +9,7 @@ import java.time.LocalDateTime;
 @Entity
 @Getter
 @Setter
-@Builder
 @NoArgsConstructor
-@AllArgsConstructor
 public class Feature {
 
     @Id
@@ -19,8 +17,9 @@ public class Feature {
     @Column(name = "FEATURE_ID")
     private Long id;
 
-    @Column(nullable = false)
-    private String vector;
+    @Convert(converter = VectorConverter.class)
+    @Column(nullable = false, columnDefinition = "TEXT")
+    private Vector vector;
 
     private LocalDateTime created_at = LocalDateTime.now();
     private LocalDateTime updated_at;

--- a/src/main/java/com/tfheauth/face_auth_server/feature/FeatureController.java
+++ b/src/main/java/com/tfheauth/face_auth_server/feature/FeatureController.java
@@ -13,10 +13,9 @@ public class FeatureController {
         this.featureService = featureService;
     }
 
-    @PostMapping("/{userId}")
-    public ResponseEntity<String> saveFeature(@PathVariable Long userId, @RequestBody FeatureRequestDTO featureRequestDTO) {
-        featureService.saveFeature(userId, featureRequestDTO);
+    @PostMapping
+    public ResponseEntity<String> saveFeature(@RequestBody FeatureRequestDTO featureRequestDTO) {
+        featureService.saveFeature(featureRequestDTO);
         return ResponseEntity.ok("Feature 저장 완료");
     }
-
 }

--- a/src/main/java/com/tfheauth/face_auth_server/feature/FeatureService.java
+++ b/src/main/java/com/tfheauth/face_auth_server/feature/FeatureService.java
@@ -4,37 +4,31 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.tfheauth.face_auth_server.user.User;
 import com.tfheauth.face_auth_server.user.UserRepository;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
 
 @Service
 public class FeatureService {
 
     private final FeatureRepository featureRepository;
     private final UserRepository userRepository;
-    private final ObjectMapper objectMapper;
 
-    public FeatureService(FeatureRepository featureRepository, UserRepository userRepository, ObjectMapper objectMapper) {
+    public FeatureService(FeatureRepository featureRepository, UserRepository userRepository) {
         this.featureRepository = featureRepository;
         this.userRepository = userRepository;
-        this.objectMapper = objectMapper;
     }
 
     // 클라이언트로부터 임베딩 벡터값 수신받아 저장
-    public void saveFeature(Long userId, FeatureRequestDTO featureRequestDTO) {
-        User user = userRepository.findById(userId)
-                .orElseThrow(() -> new RuntimeException("User not found"));
+    @Transactional
+    public void saveFeature(FeatureRequestDTO featureRequestDTO) {
+        User user = userRepository.findById(featureRequestDTO.getUserId())
+                .orElseThrow(() -> new IllegalArgumentException("사용자를 찾을 수 없습니다."));
 
-        // 임베딩을 JSON 형태로 저장
-        String vectorJson;
-        try {
-            vectorJson = objectMapper.writeValueAsString(featureRequestDTO.getEmbedding());
-        } catch (Exception e) {
-            throw new RuntimeException("Vector 변환 실패", e);
-        }
-
-        Feature feature = Feature.builder()
-                .user(user)
-                .vector(vectorJson)
-                .build();
+        Feature feature = new Feature();
+        feature.setUser(user);
+        feature.setVector(featureRequestDTO.getVector());
+        feature.setCreated_at(LocalDateTime.now());
 
         featureRepository.save(feature);
     }

--- a/src/main/java/com/tfheauth/face_auth_server/feature/Vector.java
+++ b/src/main/java/com/tfheauth/face_auth_server/feature/Vector.java
@@ -1,5 +1,6 @@
 package com.tfheauth.face_auth_server.feature;
 
+import jakarta.persistence.Embeddable;
 import lombok.Getter;
 import lombok.Setter;
 
@@ -7,8 +8,9 @@ import java.util.List;
 
 @Getter
 @Setter
-public class FeatureRequestDTO {
+@Embeddable
+public class Vector {
 
-    private Long userId;
-    private Vector vector;
+    private List<Double> c1;
+    private List<Double> c2;
 }

--- a/src/main/java/com/tfheauth/face_auth_server/feature/VectorConverter.java
+++ b/src/main/java/com/tfheauth/face_auth_server/feature/VectorConverter.java
@@ -1,0 +1,31 @@
+package com.tfheauth.face_auth_server.feature;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.persistence.AttributeConverter;
+import jakarta.persistence.Converter;
+
+// 객체 ↔ JSON 변환기
+@Converter
+public class VectorConverter implements AttributeConverter<Vector, String> {
+
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    @Override
+    public String convertToDatabaseColumn(Vector attribute) {
+        try {
+            return objectMapper.writeValueAsString(attribute);
+        } catch (JsonProcessingException e) {
+            throw new IllegalArgumentException("Vector 객체를 JSON으로 변환 실패", e);
+        }
+    }
+
+    @Override
+    public Vector convertToEntityAttribute(String dbData) {
+        try {
+            return objectMapper.readValue(dbData, Vector.class);
+        } catch (JsonProcessingException e) {
+            throw new IllegalArgumentException("JSON을 Vector 객체로 변환 실패", e);
+        }
+    }
+}

--- a/src/main/java/com/tfheauth/face_auth_server/user/UserRepository.java
+++ b/src/main/java/com/tfheauth/face_auth_server/user/UserRepository.java
@@ -10,5 +10,4 @@ public interface UserRepository extends JpaRepository<User, Long> {
 
     Optional<User> findByEmail(String email);
 
-    Optional<User> findById(Long id);
 }


### PR DESCRIPTION
 ### Feature 엔티티의 vector 속성을 아래처럼 받도록 수정하였습니다.
```
{
  "userId": 123,
  "vector": {
    "c1": [...],
    "c2": [...]
  }
}
``` 

### `AttributeConverter` 클래스를 통해 Vector ↔ JSON으로 변환하도록 하였습니다.
Feature 엔티티를 save() 하거나 findById() 할 때 vector 필드에 Vector 객체가 들어오면
→ VectorConverter.convertToDatabaseColumn()을 자동 호출해서
→ JSON 문자열로 변환 후 DB에 저장

DB에서 JSON 문자열을 읽어올 때는
→ VectorConverter.convertToEntityAttribute()가 자동 호출되어
→ Vector 객체로 복원
