### PR TITLE
modify: 벡터값 비교연산 방법 수정

### DIFF
--- a/src/main/java/com/tfheauth/face_auth_server/feature/FeatureService.java
+++ b/src/main/java/com/tfheauth/face_auth_server/feature/FeatureService.java
@@ -43,7 +43,6 @@ public class FeatureService {
 
         List<Double> c1 = requestDTO.getC1();
         List<Double> c2 = requestDTO.getC2();
-        List<Double> s = requestDTO.getS();
 
         List<Double> db_c1 = stored.getC1();
         List<Double> db_c2 = stored.getC2();

--- a/src/main/java/com/tfheauth/face_auth_server/feature/Vector.java
+++ b/src/main/java/com/tfheauth/face_auth_server/feature/Vector.java
@@ -13,5 +13,4 @@ public class Vector {
 
     private List<Double> c1;
     private List<Double> c2;
-    private List<Double> s;
 }


### PR DESCRIPTION
기존에는 클라이언트로부터 받은 벡터값 (c1, c2, s)를 비교연산하여 (d1, d2, d3) 리스트를 클라이언트에게 반환했었는데, 
받는 벡터값의 형식을 (c1, c2)로 변경하였습니다.