### PR TITLE
modify: 암호문 관련 필드&DTO를 double에서 String으로 변경

### DIFF
--- a/src/main/java/com/tfheauth/face_auth_server/feature/FeatureCompareRequestDTO.java
+++ b/src/main/java/com/tfheauth/face_auth_server/feature/FeatureCompareRequestDTO.java
@@ -10,6 +10,6 @@ import java.util.List;
 public class FeatureCompareRequestDTO {
 
     private String email;
-    private List<Double> c1;
-    private List<Double> c2;
+    private List<String> c1;
+    private List<String> c2;
 }

--- a/src/main/java/com/tfheauth/face_auth_server/feature/FeatureService.java
+++ b/src/main/java/com/tfheauth/face_auth_server/feature/FeatureService.java
@@ -5,6 +5,7 @@ import com.tfheauth.face_auth_server.user.UserRepository;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.math.BigInteger;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
@@ -41,21 +42,21 @@ public class FeatureService {
 
         Vector stored = feature.getVector();
 
-        List<Double> c1 = requestDTO.getC1();
-        List<Double> c2 = requestDTO.getC2();
+        List<String> c1 = requestDTO.getC1();
+        List<String> c2 = requestDTO.getC2();
 
-        List<Double> db_c1 = stored.getC1();
-        List<Double> db_c2 = stored.getC2();
+        List<String> db_c1 = stored.getC1();
+        List<String> db_c2 = stored.getC2();
 
         List<PolynomialCoefficientDTO> result = new ArrayList<>();
 
         for (int i = 0; i < c1.size(); i++) {
-            double tildeC1 = c1.get(i) - db_c1.get(i);
-            double tildeC2 = c2.get(i) - db_c2.get(i);
+            BigInteger tildeC1 = new BigInteger(c1.get(i)).subtract(new BigInteger(db_c1.get(i)));
+            BigInteger tildeC2 = new BigInteger(c2.get(i)).subtract(new BigInteger(db_c2.get(i)));
 
-            double a = Math.pow(tildeC1, 2);
-            double b = 2 * tildeC1 * tildeC2;
-            double c = Math.pow(tildeC2, 2);
+            BigInteger a = tildeC2.pow(2); // s^2 계수
+            BigInteger b = tildeC1.multiply(tildeC2).multiply(BigInteger.TWO); // s 계수
+            BigInteger c = tildeC1.pow(2); // 상수항
 
             result.add(new PolynomialCoefficientDTO(a, b, c));
         }

--- a/src/main/java/com/tfheauth/face_auth_server/feature/PolynomialCoefficientDTO.java
+++ b/src/main/java/com/tfheauth/face_auth_server/feature/PolynomialCoefficientDTO.java
@@ -4,11 +4,13 @@ import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.Setter;
 
+import java.math.BigInteger;
+
 @Getter
 @Setter
 @AllArgsConstructor
 public class PolynomialCoefficientDTO {
-    private double a; // 상수항
-    private double b; // 1차항
-    private double c; // 2차항
+    private BigInteger a; // 상수항
+    private BigInteger b; // 1차항
+    private BigInteger c; // 2차항
 }

--- a/src/main/java/com/tfheauth/face_auth_server/feature/Vector.java
+++ b/src/main/java/com/tfheauth/face_auth_server/feature/Vector.java
@@ -11,6 +11,6 @@ import java.util.List;
 @Embeddable
 public class Vector {
 
-    private List<Double> c1;
-    private List<Double> c2;
+    private List<String> c1;
+    private List<String> c2;
 }


### PR DESCRIPTION
프론트에서 보낸 c1, c2(BigInt 문자열)를 서버에서 Double로 받아서 dot 연산이 0이 되는 것일 가능성을 고려하여
모든 암호문, 시크릿키 관련 필드/DTO/DB를 List<String>으로 변경하였습니다.
그리고 연산부에서는 BigInteger로 변환해서 연산하도록 하였습니다.